### PR TITLE
feat: add error logging for missing workspace JSON file

### DIFF
--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import { access, constants } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
+import { logger } from './logger.js';
 
 /**
  * Converts the file path to the workspace directory provided by the user to
@@ -36,10 +37,17 @@ export function getWorkspacePathIdentifier(workspacePath: string) {
 export async function isExistingWorkspace(workspacePath: string) {
   try {
     await access(workspacePath);
-    const identifier = getWorkspacePathIdentifier(workspacePath);
+  } catch {
+    logger.error('The provided workspacePath "' + workspacePath + '" does not exist.');
+    return false;
+  }
+  
+  const identifier = getWorkspacePathIdentifier(workspacePath);
+  try {
     await access(join(workspacePath, `${identifier}.json`), constants.F_OK);
     return true;
   } catch {
+    logger.error('Expected to find the file "' + identifier + '.json" but was not found.');
     return false;
   }
 }


### PR DESCRIPTION
if a workspace is moved the hash of the workspace will change and the config file won't be found anymore. the logging should give a hint how the config file should be named.