### PR TITLE
feat: allow to capture command output to variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Each step consists of the following properties:
 
 - `type`: the type of the step; can be one of the following
   - `FORMULA`: a JavaScript formula that is executed in this step; executed via `eval`
-  - `COMMAND`: execute a command; the command is executed via NodeJS `child_process.execSync`
+  - `COMMAND`: execute a command; the command is executed via NodeJS `child_process.execSync`; if used in combination with `resultVariable` command output is captured
   - `EXECUTOR`: a special step that is connected to some build-in executor; see [Available executors](#available-executors)
   - `USE_CASE`: call another use case
   - `PROMPT`: trigger a prompt for user input

--- a/src/services/use-cases/use-case-runner.ts
+++ b/src/services/use-cases/use-case-runner.ts
@@ -173,7 +173,16 @@ export class UseCaseRunner {
         step.command!,
         context
       );
-      await execCommand(command, this.templatesAccess.getWorkspacePath());
+      const result = await execCommand(
+        command,
+        this.templatesAccess.getWorkspacePath(),
+        !!step.resultVariable
+      );
+
+      if (step.resultVariable) {
+        return { ...context, [step.resultVariable]: result };
+      }
+
       return context;
     });
   }

--- a/src/utils/processes.test.ts
+++ b/src/utils/processes.test.ts
@@ -1,0 +1,46 @@
+import { execSync } from 'node:child_process';
+import { afterEach, describe, expect, Mock, test, vi } from 'vitest';
+
+import { execCommand } from './processes.js';
+
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+describe('processes', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('execCommand', () => {
+    test('should return the output if captureStdout is true', async () => {
+      const command = 'ls -la';
+      const cwd = '/';
+      const expectedOutput = 'total 0';
+      (execSync as Mock).mockReturnValue(expectedOutput);
+
+      const output = await execCommand(command, cwd, true);
+
+      expect(execSync).toHaveBeenCalledWith(command, {
+        cwd,
+        encoding: 'utf-8',
+        stdio: 'pipe',
+      });
+      expect(output).toBe(expectedOutput);
+    });
+
+    test('should run with stdio=inherit if captureStdout is false', async () => {
+      const command = 'ls -la';
+      const cwd = '/';
+      (execSync as Mock).mockReturnValue('');
+
+      await execCommand(command, cwd, false);
+
+      expect(execSync).toHaveBeenCalledWith(command, {
+        cwd,
+        encoding: 'utf-8',
+        stdio: 'inherit',
+      });
+    });
+  });
+});

--- a/src/utils/processes.ts
+++ b/src/utils/processes.ts
@@ -2,9 +2,14 @@ import { execSync } from 'node:child_process';
 
 export const OS = process.platform;
 
-export async function execCommand(command: string, cwd: string) {
+export async function execCommand(
+  command: string,
+  cwd: string,
+  captureStdout = false
+) {
   return execSync(command, {
     cwd,
-    stdio: 'inherit',
+    encoding: 'utf-8',
+    stdio: captureStdout ? 'pipe' : 'inherit',
   });
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

So far it's a bit cumbersome if you want to capture the command output to a variable. The obvious work-around being redirecting stdout to a well-known temporary file, then using `FORMULA` type step in combination with `inputFile` and issue another command to delete the temporary file.

## What is the new behavior?

You can specify `resultVariable` prop on the `COMMAND` type step, this will run the command with output capturing.

A subsequent `FORMULA` type step can the process the result further, e.g. split by newlines etc. to prepare entities for a select prompt etc.pp

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
